### PR TITLE
Document the new COG_TELEMETRY events

### DIFF
--- a/src/reference/cog_server_configuration.adoc
+++ b/src/reference/cog_server_configuration.adoc
@@ -114,6 +114,11 @@ See also:
 *  <<COG_EMAIL_FROM>>
 *  <<COG_PASSWORD_RESET_BASE_URL>>
 
+[[COG_TELEMETRY]]`COG_TELEMETRY`::
+Whether or not Cog should send an event to the Operable telemetry service when it starts. This event contains a unique identifier (based on the SHA256 of the UUID for your operable bundle), the Cog version number, and the Elixir mix environment (:prod, :dev, etc) that Cog is running under. Set this value to `false` to disable this event from being sent.
++
+Defaults to `true`.
+
 [[COG_TRIGGER_PORT]]`COG_TRIGGER_PORT`::
 The IP port to listen on for invocation of triggers. Must be distinct from <<COG_API_PORT>>.
 // TODO: See [Invoking A Trigger](doc:triggers#invoking-a-trigger) for more details.
@@ -208,4 +213,3 @@ See also:
 Real-Time Messaging (RTM) API token used to connect to Slack. To obtain one, go to `https://<your_slack-team>.slack.com/apps/manage/custom-integrations` and click on `Bots`.
 +
 It _must_ be an RTM API token; a token for the REST API will _not_ work.
-


### PR DESCRIPTION
This should be merged when we cut the 0.16 release that includes the telemetry event. I have already updated the Operable privacy policy to reflect this data being collected.
