### PR TITLE
Rob transfer2

### DIFF
--- a/cog_book.adoc
+++ b/cog_book.adoc
@@ -39,6 +39,8 @@ include::src/writing_a_command_bundle/text.adoc[]
 
 include::src/permissions_and_rules/text.adoc[]
 
+include::src/command_execution_rules/text.adoc[]
+
 
 = *Reference*
 

--- a/cog_book.adoc
+++ b/cog_book.adoc
@@ -6,6 +6,7 @@
 :linkcss:
 :sectanchors:
 :doctype: book
+:stylesheet: stylesheets/cog.css
 
 :google-analytics-account: UA-61670076-4
 :listing-caption: Listing
@@ -21,6 +22,8 @@ NOTE: This book is released under the {license} license. More information about 
 include::src/introducing_cog/text.adoc[]
 
 include::src/installation_guide/text.adoc[]
+
+include::src/bootstrapping_cog/text.adoc[]
 
 include::src/installing_and_managing_relays/text.adoc[]
 
@@ -54,6 +57,7 @@ Here you will find detailed reference information on various aspects of the Cog 
 
 
 include::src/reference/cog_server_configuration.adoc[]
+
 include::src/reference/relay_configuration.adoc[]
 
 // == Command Environment

--- a/pygments-default.css
+++ b/pygments-default.css
@@ -1,5 +1,5 @@
 .listingblock .pygments .hll { background-color: #ffffcc }
-.listingblock .pygments  { background: #f8f8f8; }
+.listingblock .pygments, .listingblock .pygments code { background: #f8f8f8; }
 .listingblock .pygments .tok-c { color: #408080; font-style: italic } /* Comment */
 .listingblock .pygments .tok-err { border: 1px solid #FF0000 } /* Error */
 .listingblock .pygments .tok-k { color: #008000; font-weight: bold } /* Keyword */

--- a/src/bootstrapping_cog/text.adoc
+++ b/src/bootstrapping_cog/text.adoc
@@ -1,4 +1,4 @@
-== Bootstrapping Cog
+== *Bootstrapping Cog*
 
 Since interactions with Cog require a user account, you'll need to _bootstrap_ your system before you can do anything interesting with it. This process will create the necessary administrator role and user group, as well as create the first user account and place it into that administrator group. At this point, you can interact with Cog as this first privileged user in order to create other user accounts (to which you can also grant administrative access), install bundles, and perform other tasks.
 

--- a/src/bootstrapping_cog/text.adoc
+++ b/src/bootstrapping_cog/text.adoc
@@ -1,0 +1,97 @@
+== Bootstrapping Cog
+
+Since interactions with Cog require a user account, you'll need to _bootstrap_ your system before you can do anything interesting with it. This process will create the necessary administrator role and user group, as well as create the first user account and place it into that administrator group. At this point, you can interact with Cog as this first privileged user in order to create other user accounts (to which you can also grant administrative access), install bundles, and perform other tasks.
+
+There are a few ways you can bootstrap. If your Cog system is automated in any way (using Chef, Puppet, Ansible, or some flavor of AWS or Heroku deployment, for example), you may find it convenient to <<cog-environment-variables#section--cog_bootstrap_-variables, automatically bootstrap your new system using environment variables>>.
+
+Alternatively, you can use the `cogctl bootstrap` command, as detailed below.
+
+Whichever way you choose, read further on this page, as the underlying principles are the same.
+
+[source, shell]
+----
+cogctl bootstrap
+Bootstrapped
+----
+
+.`bootstrap` can Safely Run Multiple Times
+NOTE: You can run `cogctl bootstrap` multiple times; if the system is already bootstrapped, `cogctl` will alert you and return a `1` exit code, but the Cog system itself will remain unaffected.
+
+If you take a look in `~/.cogctl`, you'll begin to see what has happened.
+
+[source, shell]
+----
+cat ~/.cogctl
+[defaults]
+profile=localhost
+
+[localhost]
+host=localhost
+password=BgEocTFGzON$U39srRt5^fi(ZD0KxV*1
+port=4000
+secure=false
+user=admin
+----
+
+Here, we can see that a user named `admin` has been created for us on the Cog instance running on this machine. A password has also been generated for this user. Now, whenever we run any `cogctl` commands from this machine, these credentials will be used by default to make authenticated API calls.
+
+Cog's REST API is guarded by Cog's authorization system, which means that the admin user must have permissions to access the API somehow. As detailed in <<A Tour Through Cog's Authorization System>>, permissions must be attached to a user somehow through a combination of roles and groups. As you can probably guess, the bootstrapping process handles all this. Let's use `cogctl` to examine what has been done.
+
+First, let's just check that we actually exist :smile:
+[source, shell]
+----
+cogctl users
+USERNAME  FULL NAME
+admin     Cog Administrator
+----
+
+_phew!_
+
+Now let's examine the core permissions of the Cog system. These govern fine-grained access to the various REST API endpoints and chat commands.
+
+[source, shell]
+----
+cogctl permissions
+NAMESPACE  NAME                ID
+operable   manage_commands     a8cd921d-49a9-497a-a977-79ad50512df9
+operable   manage_groups       fa9d0311-2791-462a-9bf9-05fe29299109
+operable   manage_permissions  cf604203-f546-43cb-8677-51c698140867
+operable   manage_relays       365228d2-d082-4bfa-ac7d-ff731a92100d
+operable   manage_roles        fec52faa-5106-4982-ad0b-cbe5307c26ec
+operable   manage_triggers     4b6b01d7-0d54-4435-befd-c9bb23212404
+operable   manage_users        65de7570-7b3f-4ebd-98fd-786f9e9b5cc2
+----
+
+That's a lot of permissions; Cog helps us out by creating a `cog-admin` role to collect them all together.
+
+[source, shell]
+----
+./cogctl roles info cog-admin
+NAME       ID
+cog-admin  35569e67-433f-4e37-8497-76571f109453
+
+Permissions
+NAMESPACE  NAME                ID
+operable   manage_commands     a8cd921d-49a9-497a-a977-79ad50512df9
+operable   manage_groups       fa9d0311-2791-462a-9bf9-05fe29299109
+operable   manage_permissions  cf604203-f546-43cb-8677-51c698140867
+operable   manage_relays       365228d2-d082-4bfa-ac7d-ff731a92100d
+operable   manage_roles        fec52faa-5106-4982-ad0b-cbe5307c26ec
+operable   manage_triggers     4b6b01d7-0d54-4435-befd-c9bb23212404
+operable   manage_users        65de7570-7b3f-4ebd-98fd-786f9e9b5cc2
+----
+
+To complete the loop, we have a group that is also named `cog-admin` with the `admin` user as its sole member. This group is granted the `cog-admin` role.
+
+[source, shell]
+----
+cogctl groups info cog-admin
+ID     88f30dec-ca13-4d92-a6bd-4631acc7424b
+Name   cog-admin
+Users  cog@localhost
+Roles  cog-admin
+----
+
+Though the Cog admin user is named `admin`, there's nothing particularly special about that name.  As this tour of the bootstrapping process has shown us, the `admin` user functions as an administrator, able to perform any task in the Cog system, only because it resides in a group that has been granted all the core permissions. _Any_ user in this group would have the same capabilities.
+
+This also shows how to make any Cog user an administrator; simply add them to the `cog-admin` group.

--- a/src/command_execution_rules/text.adoc
+++ b/src/command_execution_rules/text.adoc
@@ -1,0 +1,85 @@
+== *Command Execution Rules*
+
+=== Rule Structure
+
+Rules help Cog to determine who is able to perform what task. Cog rules follow a specific format. The rule structure describes what command is executed and what permission is needed in order to execute the command. All rules begin with the phrase "```when command is```". If a user does not have the specified permission, the user is not able to execute the command.
+
+Do you have an entire group of people who should have a certain command? No problem, set up the group and assign the permission to that group.  Cog will still recognize that each user has the correct permissions according to the group.
+
+[source, shell]
+----
+when command is <bundle_name>:<command_name> must have <bundle_name|site>:<permission_name>
+----
+
+=== Arguments and Options Qualifiers
+
+You may also set rules to cover very specific invocations of a certain command. You can set option and arg values to match for particular command executions.
+
+The argument and option portion of the rules begin with the word "```with```". There are argument and option  qualifiers used in this phrasing. The possible key words and phrases that Cog recognizes and acts upon when using the argument and option qualifier phrase are as follows:
+
+* and
+* or
+* <,>, ==, !=
+
+[source, shell]
+----
+when command is <bundle_name>:<command_name> with arg[<position>] == '<some value>' must have <bundle_name|site>:<permission_name>
+----
+
+or
+
+[source, shell]
+----
+when command is <bundle_name>:<command_name> with option[<some option>] == <some value> must have <bundle_name|site>:<permission_name>
+----
+
+You may combine these qualifiers such that your rules can be as simple or as complicated as you need them to be.
+
+The following are rule examples with valid argument and option qualifiers: +
+"when command is foo:bar with option[delete] == true must have foo:destroy" +
+"when command is foo:set with option[set] == /.*/ must have foo:baz-set" +
+"when command is foo:qux with arg[0] == 'status' must have foo:view" +
+"when command is foo:barqux with option[delete] == true and arg[0] > 5 must have foo:destroy"
+
+=== Permissions
+
+Every rule must state what permissions are necessary in order to execute a certain command. The beginning of the permissions portion of the rule is indicated by the phrase "```must have```". This is where you state any and all permissions that are deemed necessary in order to execute a particular command. It is possible to only require a single permission, a certain combination, or a list of permissions. The following are the possible keywords used when declaring permissions:
+
+* or
+* and
+* any in
+* all in
+* allow
+
+
+For example, the following are rule examples with valid permission settings: +
+"when command is foo:baz must have foo:write and site:admin"
+"when command is foo:export must have all in [foo:write, site:ops] or any in [site:admin, site:management]" +
+"when command is foo:bar must have any in [foo:read, foo:write]" +
+"when command is foo:qux must have all in [foo:write, site:ops] and any in [site:admin, site:management]" +
+"when command is foo:biz allow"
+
+."Allowed" commands
+NOTE: Note the special "```allow```" keyword. "```allow```" may not be accompanied with any other keyword or phrase. Commands using this permission are allowed to be executed by any registered user in Cog.
+
+=== Site Namespace
+
+The `site` namespace is used when trying to set permissions for a user, group, or role. This does *not* have to be command specific.  You may use site permissions when deciding what group should have permissions to execute certain commands, in specific environments, within certain groups.
+
+A user can only create and delete permissions from the site namespace. You cannot delete the permissions that are part of a command bundle.
+
+For example, let's say your organization has an IT group, "it", an engineering group, "eng", and a QA group, "qa". As a result, you have 3 different environments "prod", "test" and "stage". There are certain tasks that can be performed in each environment, but you must belong to the correct group and be operating in the correct environment.
+
+So we will assume that The IT group operates in "prod", QA in "qa", and Engineering in "staging", though IT should be able to handle certain tasks in all environments such as patch updates and the sort.
+
+Let's create some example commands: foo:deploy, foo:patch, foo:delete, foo:readlog
+
+For the examples sake, we'll have the example permissions map to these commands such that they may look like: foo:p_deploy, foo:p_patch, foo:p_delete, foo:p_readlog
+
+We'll set up site permissions based on each group and each environment: site:prod, site:test, site:stage, site:it, site:qa, site:eng
+
+Some resulting rules may look like the following: +
+"when command is foo:deploy when option[environment] == 'prod' must have all in [site:it, site:prod, foo:p_deploy]" +
+"when command is foo:deploy when option[environment] == 'qa' must have site:test and foo:p_deploy" +
+"when command is foo:deploy when option[environment] == 'stage' must have site:stage and foo:p_deploy" +
+"when command is foo:patch must have all in [foo:p_patch, site:it] or all in [site:qa, site:test, foo:p_patch] or all in [site:eng, site:stage, foo:p_patch]"


### PR DESCRIPTION
Added the Bootstrapping chapter and the Command Execution rules chapters from the docs.operable.io book.

Edits to cog_book.adoc to point it to the new chapters, to allow it to use the cog.css file, and to clarify some section headers.  

Also FYI for other document editors, it looks like the include statements need to be separated by a blank line to function properly