### PR TITLE
Command development

### DIFF
--- a/cog_book.adoc
+++ b/cog_book.adoc
@@ -9,7 +9,7 @@
 :stylesheet: stylesheets/cog.css
 
 :google-analytics-account: UA-61670076-4
-:listing-caption: Listing
+//:listing-caption: Listing
 :figure-caption: Figure
 
 = The Cog Book
@@ -49,6 +49,7 @@ include::src/dynamic_command_configuration/text.adoc[]
 
 include::src/returning_data_from_cog/text.adoc[]
 
+include::src\services\text.adoc[]
 
 = Reference
 

--- a/cog_book.adoc
+++ b/cog_book.adoc
@@ -51,6 +51,8 @@ include::src/returning_data_from_cog/text.adoc[]
 
 include::src\services\text.adoc[]
 
+include::src\templates\text.adoc[]
+
 = Reference
 
 [partintro]

--- a/src/services/text.adoc
+++ b/src/services/text.adoc
@@ -1,0 +1,249 @@
+== Services
+
+=== Overview
+
+The majority of chat commands are not full fledged applications by themselves. They require access to external application APIs and other resources to function. Given there are a finite (but still large) number of applications and a much smaller number of ways to access them it's not all that surprising to see unrelated chat commands sharing a common set of requirements.
+
+Examples of these requirements include:
+
+* Managing state related to chat users and/or command execution
+* "Shelling out" to aliases/pipelines/commands
+* Accessing REST APIs
+
+=== Design Journey
+
+Cog provides a suite of services -- and later a user-extendible API -- to satisfy requirements like these. This document will discuss the general design principles of Cog services and specifics on the two services included in Cog 0.5.0: `memory` and `exec`.
+
+Four design criteria heavily influenced the design and technology choices of what became Cog Services.
+
+. Security +
+Only authorized users should be able to access services. Cog must aggressively identify and validate each access.
+. Audit +
+Service use must be part of Cog's audit log. Administrators should regard the log as a comprehensive journal of user <-> Cog interactions.
+. Flexibility +
+The overall service API design shouldn't impose unnecessary implementation limits on the types and kinds of services offered.
+. Ease of use +
+Interacting with services should be a pleasant experience for command authors. Given Cog's language agnostic design this implies services will be accessible from a wide variety of programming languages and environments.
+
+Several candidate designs and technologies were evaluated against the above principles.
+
+* **Services Over MQTT** +
+The first idea was to leverage Cog's internal message bus as a service transport exposing services directly to commands via Relay's command runtime environment.
+    ** Pros: Good security and auditability via tight integration w/Cog's existing infrastructure; Simplified service access via Relay.
+    ** Cons: Requires design and implementation of an entire RPC path and data encoding; Service clients would necessarily be one-off and custom preventing any reuse of existing libraries or protocols; Maintaining lots of custom client code eventually slows down our velocity and impacts overall flexibility; Asking users to learn yet another service client API negatively impacts ease of use.
+    ** Status: DISCARDED
+* **REST-enabled Services w/Relay Proxies** +
+We then considered exposing services over HTTP with a REST-style API. Services would be hosted on Cog, "tunneled" over MQTT, and published on each Relay as REST APIs served by HTTP servers bound to localhost.
+    ** Pros: Restricting service access to processes running on Relay hosts reduces service's overall attack footprint; Using HTTP transport and REST API design allows us to leverage existing libraries across a wide range of programming langauges.
+    ** Cons: Two service APIs are required: MQTT and HTTP/REST; Unclear how to simply map a message-driven API to REST especially in an automated fashion; Proxying calls from Relay to Cog is non-trivial and likely to become more complicated over time
+    ** Status: DISCARDED
+* **REST-enabled Services w/Token-based authentication** +
+Finally, we considered a refined version of the prior idea. REST-style services would be hosted and published on Cog via a separate HTTP listener, a la pipeline triggers. Accessing services will require a special token unique to each pipeline instance. This allows Cog to connect a service call with a user which preserves auditability. Cog can also use the token to propagate a user's identity and permissions across service calls thereby supporting a strong security model.
+    ** Pros: Relatively straightforward to design and implement; Reuses existing concepts (and potentially code) from other Cog subsystems including ACL evaluation and pipeline triggers; Allows command author's to use their preferred HTTP/REST library; Well defined API semantics; Clear path to user extensibility in the future
+    ** Cons: Some complexity around pipeline token generation and invalidation; Increased attack surface compared to previous options
+    ** Status: SELECTED
+
+=== Cog Services API
+
+Cog services will be managed by a separate Phoenix endpoint named `Cog.PlatformServicesEndpoint`. Building the API as a separate endpoint instead of a separate Phoenix app was chosen to avoid packaging and reuse issues with Cog (since it was never designed to be a reusable library) and also reduce the coding effort. An endpoint-based implementation strikes a good balance between isolation, modularity, and speed of development without constraining future choices.
+
+The endpoint will contain its own HTTP router with the majority of application logic contained in controllers and views. The root URL of the services API will be exported to the command runtime environment under the environment variable `COG_SERVICES_ROOT`. It shall be a valid URL starting with either `http://` or `https://`, depending on user configuration, followed by the host name or IP address and listening port number. Examples: `http://192.168.2.22:4005`, `https://mycog.somecorp.com:4100`.
+
+==== Authentication and Authorization
+
+Cog will generate a unique pipeline token upon pipeline initialization. The token will correlate a pipeline to the calling user much like REST API tokens correlate REST API sessions to calling users. Pipeline tokens have a finite lifespan. Their expiration will be triggered by the completion (regardless of status) of the owning pipeline.
+
+The token will be exported to the command runtime environment under the environment variable `COG_PIPELINE_TOKEN`. All calls to the Cog Service API _must_ include the token in their `Authorization` HTTP header like so: `Authorization: pipeline <token>`. Requests without a properly formed `Authorization` header or referencing an expired or invalid pipeline token will receive `401 Unauthorized`.
+
+==== Routes
+
+The Services API provides an informational API to assist monitoring, service discovery, and service enumeration. These endpoints are listed below.
+
+==== /services/meta
+
+Returns a JSON object describing Cog version, Cog Services API version, and basic information about each hosted service. The below JSON document can be used as a normative reference.
+
+.Request
+[source, http]
+----
+GET /services/meta HTTP/1.1
+Authorization: pipeline 123456789
+----
+
+.Response
+[source, http]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{"info":
+  {
+    "cog_version": "0.5.0",
+    "cog_services_api_version": "1",
+    "services": [{"name": "exec",
+                  "version": "1.0"},
+                 {"name": "state",
+                  "version": "1.0"}]
+  }
+}
+----
+
+=== Memory Service
+
+Command invocations are essentially stateless. Cog's pipeline execution model instantiates a fresh command instance for each invocation, operating system process or Docker container depending on command bundle packaging, with no ability to refer to data from previous invocations or store data for future invocations. This is by design as it simplifies pipeline management and execution and encourages development of small, composable, stateless commands.
+
+There are times where state is simply required. Commands which need access to all prior pipeline output are difficult if not impossible to build without state. Unix CLI like `sort` and `uniq` are good examples. The memory service is intended to address precisely these kinds of requirements.
+
+==== Data Model
+
+The memory service's API resembles a hash map with two kinds of put (accumulating or replacing) and delete.
+
+.Data lifetime and visibility
+NOTE: The visibility and lifetime of data stored in the memory service is tied to the lifetime of the enclosing pipeline. This means commands executing under separate pipelines can see different values or even no value at all for the same key. Once a pipeline has exited the memory service will flush all data stored by command executing in that pipeline.
+
+
+==== /services/memory/1.0/{key}
+
+Returns the current value of `{key}`. Returns 404 for missing keys.
+
+.Request
+[source, HTTP]
+----
+GET /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{"key": "foo",
+ "value": [1,2,3,4,5]}
+----
+
+==== /services/memory/1.0/{key}
+
+Stores or updates the value corresponding to `{key}`. If `{key}` already exists then an update will be performed based on the value of the `op` field.
+
+===== Accumulate (Default)
+
+.Request
+[source, HTTP]
+----
+POST /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+Content-Type: application/json
+
+{
+  "op": "accum",
+  "value": 2
+}
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{
+  "value": [1,2]
+}
+----
+
+.Request
+[source, HTTP]
+----
+POST /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+Content-Type: application/json
+
+{
+  "op": "accum",
+  "value": [2, 3]
+}
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{
+  "value": [1,[2,3]]
+}
+----
+
+.Request
+[source, HTTP]
+----
+POST /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+Content-Type: application/json
+
+{
+  "op": "accum",
+  "value": [2, 3]
+}
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{
+  "value": [{"hello": "world"}, [2, 3]]
+}
+----
+
+===== Replace
+
+.Request
+[source, HTTP]
+----
+POST /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+Content-Type: application/json
+
+{
+  "op": "replace",
+  "value": 2
+}
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ...
+
+{
+  "value": 2
+}
+----
+
+==== /services/memory/1.0/{key}
+
+.Request
+[source, HTTP]
+----
+DELETE /services/memory/1.0/foo HTTP/1.1
+Authorization: pipeline 123456789
+----
+
+.Response
+[source, HTTP]
+----
+HTTP/1.1 204 OK
+----

--- a/src/templates/text.adoc
+++ b/src/templates/text.adoc
@@ -1,0 +1,67 @@
+== Templates
+_Formatting pipeline output for humans!_
+
+In contrast to traditional command-line programs, the output of a Cog command is not plain text, but a JSON object. This common structure makes it easy to chain commands together into pipelines because downstream commands can easily reach into the JSON output to extract the data they need, without having to jump through the various text manipulation steps that are so frequently part of traditional command-line pipelines. When it's time to present the final output of a pipeline, however, we often want something a bit more user-friendly than a dump of JSON data in our chat window.
+
+To address this, Cog commands have the ability to specify a template that will be used to process the final pipeline output into a more readable format. This allows commands to return rich JSON objects for maximum flexibility in pipelines, but also condense these objects down to the salient information that humans need in chat ("Bundle 'foo', version '1.0.0' was enabled", for example).
+
+=== Basic Greenbar Syntax
+
+The template language used by Cog is https://github.com/operable/greenbar[Greenbar], a language created by Operable for the needs of Cog. It is probably best described as a Markdown variant, with support for ERB-like tags.
+
+Many familiar Markdown features are available, including boldface, italics, ordered and unordered lists, and monospace formatting; even tables. Iteration and conditional logic (among other features) are achieved through the use of "tags". Data from result objects can be accessed through variable references. This example will illustrate many Greenbar features:
+
+.Example Greenbar Template
+[source, Markdown]
+----
+~if cond=length($results) == 1~
+The _only_ member of the group is **~$results[0].username~**.
+~end~
+~if cond=length($results) > 1~
+The group has the following members:
+~each var=$results as=user~
+1. ~$user.username~
+~end~
+~end~
+----
+
+Note that all Greenbar instructions are enclosed in `~` characters. Some, like `~if~` and `~each~` have bodies, with corresponding `~end~` terminators; bodies may contain plain text, or other Greenbar instructions. Variable dereferencing is achieved with the use of the `$` operator within Greenbar instructions. Complex objects can be navigated using familiar dot notation, and individual array members can be addressed by a zero-based index. Markdown does not require special Greenbar instructions, but is used directly (observe the italics on "only", the bolding of the single user's name, and the generation of an ordered list in the `~each~` iterator). Note also the presence of the top-level "results" key, containing all the output of the Cog pipeline.
+
+.TL;DR - How Do I Write Templates?!
+NOTE: While this document gives an overview of Greenbar, the best source of documentation for the Greenbar system can be found in https://github.com/operable/greenbar[Greenbar's code].
+ +
+ Template authors will want to pay particular attention to the documentation for https://github.com/operable/greenbar/blob/master/lib/greenbar/tags[individual tags] in the Greenbar repository.
+ +
+ Numerous example Greenbar templates can also be found in https://github.com/operable/cog/tree/master/priv/templates[Cog itself].
+
+=== Overall Template Processing Logic
+
+In order to write effective templates, it helps to understand a bit about how Cog processes the output of pipelines, how templates are chosen, and how pipeline data is presented to the template.
+
+==== All pipelines return a "results" list
+
+For all successful pipeline runs, Cog will return a single JSON object to the template. This object will have a "results" key, which is always a list of objects returned from individual command invocations (it's a list whether there is only a single result object or many).
+
+==== Commands can specify a template when they return to Cog
+
+When each command runs, it has the option of specifying a template to use when formatting the output by returning a `COG_TEMPLATE` value in the output. The name of the template is resolved relative to the bundle the command is a member of. If no template is specified, then Cog will fall back to one of two "common" templates. If the command returns bare text (instead of JSON, as is customary), then a special "text" template is used. On the other hand, if JSON is returned, then the "raw" template is used, which will pretty-print the results.
+
+==== Last output "wins"
+
+The return value of every Cog command invocation can specify a template to use, but pipelines can trigger multiple invocations in the course of processing. That can theoretically result in multiple templates being specified.
+
+Templates are only truly needed at the end of a pipeline, however. If a command in the middle of a pipeline declares that its output should be formatted with the "foo" template, we don't care, because we know that output is going to be modified further by the downstream commands. As soon as Cog wraps up one pipeline stage and moves on to the next, all template information collected to that point is discarded.
+
+With respect to templating, it is the final stage that we care about. With Cog's current implementation, each invocation can theoretically specify a different template; in reality, though, only the template specified by the final invocation is used to template all the data.
+
+==== Meta-templates, not Templates
+
+Cog's templates are not actually templates, but rather "meta-templates". They do not generate text, but rather _directives_, instructions on how to render text. This allows individual chat providers to determine exactly how to format a given template. For example, the Slack provider can interpret a `bold` directive as `*bold text*`, while a HipChat provider can interpret the same directive as `<b>bold text</b>`.
+
+.Slack's Directive Processor
+NOTE: You can see how Greenbar directives are processed for Slack in the code https://github.com/operable/cog/blob/72308c31f49e8d8369f48ec1dd932403117e232c/lib/cog/chat/slack/template_processor.ex[here].
+
+By using this architecture, command authors only need to write a single template, which each chat provider can interpret in the best way for its host platform, instead of having to supply a template for each chat provider individually.
+
+.A Familiar Architecture
+NOTE: The rendering of Greenbar templates to general directives, which are then processed by chat adapter-specific processors, is analogous to the interpretation of Java bytecode on platform-specific VMs, or the rendering of OpenGL directives by different graphics processors.


### PR DESCRIPTION
Added Services and Templates from http://docs.operable.io/v0.16

Also commented out the listing-caption attribute to eliminate unwanted numbering for source blocks.