### PR TITLE
Remove unnecessary references of RELAY_MANAGED_DYNAMIC_CONFIG

### DIFF
--- a/src/dynamic_command_configuration/text.adoc
+++ b/src/dynamic_command_configuration/text.adoc
@@ -153,7 +153,7 @@ NOTE: <<Installing and Managing Relays>> +
 
 While manually-managed dynamic configuration is simple, it can be cumbersome if you run multiple Relays, or do not have filesystem access to your Relay (as is the case with https://cog.operable.io[Hosted Cog]). In this case, you can submit your dynamic configuration layer files to Cog and it will distribute the values to your Relays as appropriate.
 
-To enable this mode of operation, your Relay(s) will need to be configured using the <<RELAY_MANAGED_DYNAMIC_CONFIG>> option. Managed Relays check in with their Cog server periodically (every 5 seconds by default; see <<RELAY_MANAGED_DYNAMIC_CONFIG_INTERVAL>>) to refresh their configuration data.
+By default your Relay(s) already supports managed dynamic config, but you can always disable it by setting <RELAY_MANAGED_DYNAMIC_CONFIG>> to `false`. Managed Relays check in with their Cog server periodically (every 5 seconds by default; see <<RELAY_MANAGED_DYNAMIC_CONFIG_INTERVAL>>) to refresh their configuration data.
 
 .Managed Mode is Enabled on Relays, Not on Cog
 NOTE: Currently, managed configuration mode requires each individual Relay to be configured as such; it is not a centrally-enabled option. Future versions of Cog and Relay may change this.

--- a/src/installation_guide/text.adoc
+++ b/src/installation_guide/text.adoc
@@ -312,7 +312,6 @@ exporting those variables we can run the run the binary we previously built.
 export RELAY_ID=`uuid` && echo $RELAY_ID
 export RELAY_COG_TOKEN=`openssl rand -hex 12` && echo $RELAY_COG_TOKEN
 export RELAY_DYNAMIC_CONFIG_ROOT=/tmp/dynamic_configs
-export RELAY_MANAGED_DYNAMIC_CONFIG=true
 _build/relay
 ----
 

--- a/src/reference/relay_configuration.adoc
+++ b/src/reference/relay_configuration.adoc
@@ -144,7 +144,7 @@ Controls whether or not Relay pulls dynamic configuration for installed command 
 +
 If set to true, Relay will retrieve dynamic configuration files from the Cog server, instead of relying on files placed on the Relay host itself. Configuration changes can be submitted to Cog via the API, and will be picked up by Relay when it checks in periodically. See <<RELAY_MANAGED_DYNAMIC_CONFIG_INTERVAL>>.
 +
-Defaults to `false`.
+Defaults to `true`.
 
 [[RELAY_DYNAMIC_CONFIG_ROOT]]`RELAY_DYNAMIC_CONFIG_ROOT`::
 File path used to store dynamic bundle configuration files. A missing or empty value disables this feature. Nonexistent paths will be created on first use.


### PR DESCRIPTION
Now that RELAY_MANAGED_DYNAMIC_CONFIG defaults to true, we no longer
need to reference it in a few places and instead just need to mention
that it can be set to false.