### PR TITLE
Sd/brandingcommentary

### DIFF
--- a/src/installation_guide/text.adoc
+++ b/src/installation_guide/text.adoc
@@ -69,6 +69,9 @@ https://my.slack.com/services/new/bot[New Bot Integration Page], create a new
 bot, and copy the newly generated token; it should look something like
 `xoxb-87931061512-4m0DshC79h8tLNjTMuxxozUo`.
 
+While you are over in Slack making your bot, add a cute Cog avatar too. Find a Cog avatar and other Cog branded goodies in the https://drive.google.com/open?id=0B9shLHjT25r-SkhqSTU2MG05dG8[Operable + Cog Brand Folder]
+
+
 You'll also need to export a `COG_HOST` variable. This is not a proper https://cog-book.operable.io/#_cog_server_configuration[Cog Server Configuration], but one specifically for use with this `docker-compose` example. This is the host that the Cog API will be made available at. Set this to point to your Docker host. If you're using https://docs.docker.com/machine/[docker-machine for example], this would suffice:
 
 .Export Environment Variables

--- a/src/introducing_cog/text.adoc
+++ b/src/introducing_cog/text.adoc
@@ -18,7 +18,7 @@ Build new bot commands in any language
 Commands return structured data to allow for creative adaptation in pipelines
 
 Built in templating allows the command response to be formatted for the current chat provider without embedding markup in your logic
----
+
 
 ---
 image::images/adaptability.svg[Adaptable,200,200,float="left"]
@@ -28,7 +28,7 @@ image::images/adaptability.svg[Adaptable,200,200,float="left"]
 Unix-style pipelines allow you to combine a series of simple commands to solve complex, unexpected problems
 
 Support for output redirection lets you make sure everyone is in the loop
----
+
 
 ---
 image::images/security.svg[Secure,200,200,float="left"]
@@ -63,10 +63,11 @@ Keep up to date on all things Cog by following icon:twitter[] https://twitter.co
 == Get Started
 Here are a few things you will need to do first.
 
-. Join our http://slack.operable.io/[Cog Public Chat] to chat with the Operable team and the Cog community. This is the best place to get realtime help.
+. Join our http://slack.operable.io/[Slack Cog Public Chat] to chat with the Operable team and the Cog community. This is the best place to get realtime help.
 . Head over to the <<Installation Guide>> and start installing Cog. Have questions? Ask us!
 . Once installed, make Cog do something. Read up on <<Commands and Bundles>>
 . Do you want to expand Cog's command capabilities? Easy, start <<Building Command Bundles>>.
+. Looking for Enterprise solutions like a fully integrated Cog, dedicated support, or consultation by our team? Read more on our http://operable.io/enterprise.html[Enterprise page]. 
 
 === Communication
 Let's set expectations. If you have a question, concern, idea, helpful hint, or want to tell us that you are hungry, we are listening. Please be as candid with us as possible. You can't hurt our feelings...too much. So that we can communicate as easily as possible we have several channels that you can use at anytime.


### PR DESCRIPTION
Adding mention of Cog avatar + branding page to Slack bot creation (for avatar use). Also added a single line to “Get started” regarding Enterprise solutions. This needs to become more robust and upfront.