### PR TITLE
Level 0 Titles

### DIFF
--- a/cog_book.adoc
+++ b/cog_book.adoc
@@ -20,6 +20,8 @@
 
 NOTE: This book is released under the {license} license. More information about contributing to this book along with access to the source code and previous releases is available at {repository}. If you would prefer to read this book as a PDF, you may download it {homepage}cog_book.pdf[here].
 
+= Getting Started
+
 include::src/introducing_cog/text.adoc[]
 
 include::src/installation_guide/text.adoc[]
@@ -38,9 +40,13 @@ include::src/configuring_password_resets/text.adoc[]
 
 include::src/writing_a_command_bundle/text.adoc[]
 
+= Securing Chat Commands
+
 include::src/permissions_and_rules/text.adoc[]
 
 include::src/command_execution_rules/text.adoc[]
+
+= Command Development
 
 include::src/bundle_configs/text.adoc[]
 
@@ -54,10 +60,13 @@ include::src/services/text.adoc[]
 
 include::src/templates/text.adoc[]
 
+= Tutorials
+
 include::src/installing_your_first_command_bundle/text.adoc[]
 
 include::src/developing_a_trigger/text.adoc[]
 
+= Learning More
 
 include::src/cog_architecture/text.adoc[]
 


### PR DESCRIPTION
Added chapter group titles to match the grouping used in the docs.operable.io book.  Used Level 0 headers in the cog_book.adoc itself to make this level of groupings easier to review and manage in the future.   I did not change the sidebar TOC formatting.  That will need review.