### PR TITLE
Fix missing COG_PIPELINE_TIMEOUT

### DIFF
--- a/cog-book/source/references/cog_server_configuration.rst
+++ b/cog-book/source/references/cog_server_configuration.rst
@@ -208,6 +208,14 @@ variables and describes their usage.
     See also :ref:`[COG\_API\_URL\_BASE] <COG_API_URL_BASE>` and
     :ref:`[COG\_TRIGGER\_URL\_BASE] <COG_TRIGGER_URL_BASE>`.
 
+.. _COG_PIPELINE_TIMEOUT:
+
+``COG_PIPELINE_TIMEOUT``
+    Amount of time (in seconds) to wait for execution of pipeline to
+    complete.
+
+    Defaults to ``60`` seconds.
+
 .. _COG_SERVICE_URL_HOST:
 
 ``COG_SERVICE_URL_HOST``

--- a/cog-book/source/references/cog_server_configuration.rst
+++ b/cog-book/source/references/cog_server_configuration.rst
@@ -197,6 +197,14 @@ variables and describes their usage.
 
     -  :ref:`[COG\_SMTP\_VARIABLES] <COG_SMTP>`
 
+.. _COG_PIPELINE_TIMEOUT:
+
+``COG_PIPELINE_TIMEOUT``
+    Amount of time (in seconds) to wait for execution of pipeline to
+    complete.
+
+    Defaults to ``60`` seconds.
+
 .. _COG_SERVICE_URL_BASE:
 
 ``COG_SERVICE_URL_BASE``
@@ -207,14 +215,6 @@ variables and describes their usage.
 
     See also :ref:`[COG\_API\_URL\_BASE] <COG_API_URL_BASE>` and
     :ref:`[COG\_TRIGGER\_URL\_BASE] <COG_TRIGGER_URL_BASE>`.
-
-.. _COG_PIPELINE_TIMEOUT:
-
-``COG_PIPELINE_TIMEOUT``
-    Amount of time (in seconds) to wait for execution of pipeline to
-    complete.
-
-    Defaults to ``60`` seconds.
 
 .. _COG_SERVICE_URL_HOST:
 


### PR DESCRIPTION
This PR introduces the dynamic content for `COG_PIPELINE_TIMEOUT` in source.