### PR TITLE
Fix several inconsistencies with code-block formatting

### DIFF
--- a/cog-book/source/references/command_output_tags.rst
+++ b/cog-book/source/references/command_output_tags.rst
@@ -46,11 +46,11 @@ JSON response passed to the instances template:
     [
       {
         "instance_id": "i-1984f3",
-        "instance_type: "t2.micro"
+        "instance_type": "t2.micro"
       },
       {
         "instance_id": "i-2a7b11",
-        "instance_type: "t2.small"
+        "instance_type": "t2.small"
       }
     ]
 

--- a/cog-book/source/references/command_output_tags.rst
+++ b/cog-book/source/references/command_output_tags.rst
@@ -17,7 +17,7 @@ template specified and sent to chat as shown below.
 
 Output from command:
 
-::
+.. code-block:: console
 
     COGCMD_DEBUG: Requst took 53ms to complete
     COG_TEMPLATE: instances
@@ -35,13 +35,13 @@ Output from command:
 
 Relay logs:
 
-::
+.. code-block:: console
 
     DEBU[2016-12-06T11:10:14-05:00] (P: 2b113f571dc14419870cffe5d5064e69 C: ec2:instance-list) Request took 53ms to complete
 
 JSON response passed to the instances template:
 
-::
+.. code-block:: json
 
     [
       {
@@ -66,7 +66,7 @@ provided.
 
 Output from command:
 
-::
+.. code-block:: console
 
     INSTANCE_ID  INSTANCE_TYPE
     COGCMD_INFO: 2 instances returned
@@ -76,13 +76,13 @@ Output from command:
 
 Relay logs:
 
-::
+.. code-block:: console
 
     INFO[2016-12-06T11:10:14-05:00] (P: 2b113f571dc14419870cffe5d5064e69 C: ec2:instance-list) 2 instances returned
 
 JSON response passed to the monospace template:
 
-::
+.. code-block:: json
 
     [
       {

--- a/cog-book/source/references/greenbar_tags.rst
+++ b/cog-book/source/references/greenbar_tags.rst
@@ -232,7 +232,7 @@ Any other attributes will be interpreted as custom fields and included
 in the attachments' ``fields`` field. Custom fields have the following
 structure:
 
-.. code-block: json
+.. code-block:: json
 
   {
     "title": <attribute\_name>,

--- a/cog-book/source/references/greenbar_tags.rst
+++ b/cog-book/source/references/greenbar_tags.rst
@@ -318,9 +318,9 @@ would render the text
 
 .. code-block:: json
 
-{
-  "foo": "bar",
-  "stuff": {
-    "hello": "world"
-  }
-}
+    {
+      "foo": "bar",
+      "stuff": {
+        "hello": "world"
+      }
+    }

--- a/cog-book/source/references/greenbar_tags.rst
+++ b/cog-book/source/references/greenbar_tags.rst
@@ -301,12 +301,12 @@ With ``my_json`` equal to
 
 .. code-block:: json
 
-  {
-  "foo": "bar",
-  "stuff": {
-    "hello": "world"
-  }
-  }
+    {
+      "foo": "bar",
+      "stuff": {
+        "hello": "world"
+      }
+    }
 
 the template
 
@@ -318,9 +318,9 @@ would render the text
 
 .. code-block:: json
 
-  {
+{
   "foo": "bar",
   "stuff": {
     "hello": "world"
   }
-  }
+}

--- a/cog-book/source/references/greenbar_tags.rst
+++ b/cog-book/source/references/greenbar_tags.rst
@@ -20,6 +20,7 @@ Example
 Given the variable ``$doit`` is bound, the above template would produce:
 
 ::
+
   Hello there!
 
 Given that the variable ``$doit`` is not bound, the above template would
@@ -231,7 +232,7 @@ Any other attributes will be interpreted as custom fields and included
 in the attachments' ``fields`` field. Custom fields have the following
 structure:
 
-::
+.. code-block: json
 
   {
     "title": <attribute\_name>,
@@ -298,7 +299,7 @@ Examples
 
 With ``my_json`` equal to
 
-::
+.. code-block:: json
 
   {
   "foo": "bar",
@@ -315,7 +316,7 @@ the template
 
 would render the text
 
-::
+.. code-block:: json
 
   {
   "foo": "bar",

--- a/cog-book/source/sections/installation_guide.rst
+++ b/cog-book/source/sections/installation_guide.rst
@@ -119,7 +119,7 @@ You should see Docker downloading and starting images for Cog, Relay and
 a database. This might take a while, but once it’s done starting up and
 has connected you should start seeing logs like the following:
 
-::
+.. code-block:: console
 
   cog\_1 \| 2016-10-07T00:38:51.0504 (Cog.BusEnforcer:60) [info] Allowed connection for Relay 00000000-0000-0000-0000-000000000000
 

--- a/cog-book/source/sections/introducing_cog.rst
+++ b/cog-book/source/sections/introducing_cog.rst
@@ -8,7 +8,7 @@ Powerful access control means you can collaborate around even the most sensitive
 Current Features
 ================
 
-Cog is under heavy development and is getting smarter all the time. This list of features gives you an idea of how Cog was built as well as the things that Cog knows how to do.
+This list of features gives you an idea of how Cog was built as well as the things that Cog knows how to do.
 
 
 Extensibility

--- a/cog-book/source/sections/returning_data_from_cog.rst
+++ b/cog-book/source/sections/returning_data_from_cog.rst
@@ -19,14 +19,14 @@ most common are ``JSON`` and ``COG_TEMPLATE:``.
 
    For example printing this to stdout:
 
-::
+.. code-block:: console
 
   JSON
   {"foo":"bar"}
 
 would result in Cog returning:
 
-::
+.. code-block:: json
 
   { "foo": "bar" }
 
@@ -38,7 +38,7 @@ would result in Cog returning:
 
    For example printing this to stdout:
 
-::
+.. code-block:: console
 
   COG_TEMPLATE: foo_template
   JSON

--- a/cog-book/source/sections/returning_data_from_cog.rst
+++ b/cog-book/source/sections/returning_data_from_cog.rst
@@ -44,8 +44,7 @@ would result in Cog returning:
   JSON
   {"foo":"bar"}
 
-would tell cog to render the 'foo_template' with the json
-   '{"foo":"bar"}'.
+would tell cog to render the 'foo_template' with the json ``'{"foo":"bar"}'``.
 
 Additionally there are several other output markers for logging to the
 relay console. Log messages have the prefix ``COGCMD_`` followed by the

--- a/cog-book/source/sections/writing_a_command_bundle.rst
+++ b/cog-book/source/sections/writing_a_command_bundle.rst
@@ -1267,7 +1267,7 @@ notified and is downloading the image:
 
 **Retrieving the Bundle Image in Relay’s Logs.**
 
-.. code-block: console
+.. code-block:: console
 
     DEBU[2016-09-21T12:22:06-04:00] Refreshing command catalog.
     DEBU[2016-09-21T12:22:06-04:00] Processing bundle catalog updates.

--- a/cog-book/source/sections/writing_a_command_bundle.rst
+++ b/cog-book/source/sections/writing_a_command_bundle.rst
@@ -178,12 +178,17 @@ our terminal, as seen in :ref:`Executing the Pure Ruby tweet<execute-pure-ruby-t
 .. code-block:: bash
   :linenos:
 
-    $ bundle install
-    $ export TWITTER_CONSUMER_KEY=XXXX
-    $ export TWITTER_CONSUMER_SECRET=XXXX
-    $ export TWITTER_ACCESS_TOKEN=XXXX
-    $ export TWITTER_ACCESS_TOKEN_SECRET=XXXX
-    $ ./tweet.rb This is an interesting tweet
+    bundle install
+    export TWITTER_CONSUMER_KEY=XXXX
+    export TWITTER_CONSUMER_SECRET=XXXX
+    export TWITTER_ACCESS_TOKEN=XXXX
+    export TWITTER_ACCESS_TOKEN_SECRET=XXXX
+    ./tweet.rb This is an interesting tweet
+
+Outputs:
+
+.. code-block:: console
+
     Message: This is an interesting tweet
     URL:     https://twitter.com/CogTesting/status/776507696396791809
 
@@ -497,7 +502,7 @@ Cog. We’ll use ``cogctl``:
 
 **Installing a Bundle: The Quick Way.**
 
-::
+.. code-block:: bash
 
     $ cogctl bundle install config.yaml --enable --relay-group=default
 
@@ -515,11 +520,11 @@ This is equivalent to:
 
 **Installing a Bundle: The Verbose Way.**
 
-::
+.. code-block:: bash
 
-    $ cogctl bundle install config.yaml
-    $ cogctl bundle enable twitter_example 0.0.1
-    $ cogctl relay-group assign default twitter_example
+    cogctl bundle install config.yaml
+    cogctl bundle enable twitter_example 0.0.1
+    cogctl relay-group assign default twitter_example
 
 If you look back at our bundle definition, you’ll notice that the path
 to the executable is on my workstation. When a Relay gets the request to
@@ -617,9 +622,9 @@ Uploading this file to Cog requires another ``cogctl`` invocation.
 
 **Uploading Dynamic Configuration to Cog.**
 
-::
+.. code-block:: bash
 
-    $ cogctl bundle config create twitter_example dynamic_configuration.yaml
+    cogctl bundle config create twitter_example dynamic_configuration.yaml
 
 Now, we should be able to run our command completely within Cog.
 
@@ -1197,9 +1202,9 @@ Creating the image is simple.
 
 **Building the Bundle Image.**
 
-::
+.. code-block:: bash
 
-    $ docker build -t cog-book/twitter .
+    docker build -t cog-book/twitter .
 
 Now we need to tell Cog that this bundle is a Docker bundle, and which
 image should be used to run it.
@@ -1745,7 +1750,7 @@ automatically.
 
 **Command Output in Relay Logs.**
 
-::
+.. code-block:: console
 
     WARN[2016-09-23T14:10:18-04:00] (P: d3097cc6b413473780b9aa9596273586 C: twitter_example:recent_tweets) Starting
     INFO[2016-09-23T14:10:18-04:00] (P: d3097cc6b413473780b9aa9596273586 C: twitter_example:recent_tweets) Authenticated

--- a/cog-book/source/sections/writing_a_command_bundle.rst
+++ b/cog-book/source/sections/writing_a_command_bundle.rst
@@ -286,16 +286,16 @@ following code *is* Cog to our nascent command.
 .. code-block:: bash
     :linenos:
 
-    $ export TWITTER_CONSUMER_KEY=XXXX
-    $ export TWITTER_CONSUMER_SECRET=XXXX
-    $ export TWITTER_ACCESS_TOKEN=XXXX
-    $ export TWITTER_ACCESS_TOKEN_SECRET=XXXX
+    export TWITTER_CONSUMER_KEY=XXXX
+    export TWITTER_CONSUMER_SECRET=XXXX
+    export TWITTER_ACCESS_TOKEN=XXXX
+    export TWITTER_ACCESS_TOKEN_SECRET=XXXX
 
-    $ export COG_ARGC="2"
-    $ export COG_ARGV_0="Hello"
-    $ export COG_ARGV_1="World"
+    export COG_ARGC="2"
+    export COG_ARGV_0="Hello"
+    export COG_ARGV_1="World"
 
-    $ ./tweet_cog_wrapper.sh
+    ./tweet_cog_wrapper.sh
 
 **Annotations by line number:**
 

--- a/cog-book/source/sections/writing_a_command_bundle.rst
+++ b/cog-book/source/sections/writing_a_command_bundle.rst
@@ -504,7 +504,7 @@ Cog. We’ll use ``cogctl``:
 
 .. code-block:: bash
 
-    $ cogctl bundle install config.yaml --enable --relay-group=default
+    cogctl bundle install config.yaml --enable --relay-group=default
 
 Here, we do several things at once. First, we upload the contents of our
 bundle definition to Cog. By adding the ``--enable`` flag, we also make
@@ -1267,7 +1267,7 @@ notified and is downloading the image:
 
 **Retrieving the Bundle Image in Relay’s Logs.**
 
-::
+.. code-block: console
 
     DEBU[2016-09-21T12:22:06-04:00] Refreshing command catalog.
     DEBU[2016-09-21T12:22:06-04:00] Processing bundle catalog updates.

--- a/style-guide/source/style_guide.rst
+++ b/style-guide/source/style_guide.rst
@@ -4,7 +4,7 @@ The Cog Book Author Style Guide
 This document is meant as both description and example to encourage
 standard practices amongst Cog Book contributors. It will include
 preferred or recommended approaches for selecting among reStructuredText
-formatting options, organizing information flow, and presenting code and
+formatting options, organising information flow, and presenting code and
 other examples. It also contains the complete list of approved jokes,
 witticisms, and wry remarks acceptable for adding levity to The Cog
 Book.
@@ -123,6 +123,10 @@ Use appropriate code designations (yaml, bash, sh, shell…).
 Use ``bash`` for command line interface examples unless you have a
 specific reason to use another option.
 
+**Console output**
+
+Whenever an output of a console command (docker logs, execution lines) use ``console``.
+
 **Configuration files.**
 
 Most configuration files should be sourced in ``YAML``.
@@ -204,7 +208,7 @@ Just don't get carried away.
   Don’t do this.
 
   .. warning::
-  
+
     What is wrong with you?
 
 Images


### PR DESCRIPTION
Closes #24 

- uses `code-block: console` for anything related to "command will print ... to stdout" or "logs will look like this".
- uses `code-block: json` for any json-looking output
- greenbar remains as unformatted code-block `::`
- Slack messages remain as unformatted code-block `::`
- removes `$` from bash commands (consistency)

Along the way I remove some texts which are obsolete.